### PR TITLE
docs: add infrastructure design for infrastructure and operational support

### DIFF
--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -3,7 +3,7 @@
 ## Project Information
 - **Project Type**: Greenfield
 - **Start Date**: 2026-05-04T21:37:02+09:00
-- **Current Stage**: CONSTRUCTION - NFR Design (Infrastructure and Operational Support / Planning)
+- **Current Stage**: CONSTRUCTION - Infrastructure Design (Infrastructure and Operational Support / Planning)
 
 ## Execution Plan Summary
 - **Total Stages**: 10
@@ -39,7 +39,7 @@
 ### CONSTRUCTION PHASE
 - [x] Functional Design
 - [x] NFR Requirements
-- [ ] NFR Design
+- [x] NFR Design
 - [ ] Infrastructure Design
 - [ ] Code Generation
 - [ ] Build and Test
@@ -49,7 +49,7 @@
 
 ## Current Status
 - **Lifecycle Phase**: CONSTRUCTION
-- **Current Stage**: NFR Design
+- **Current Stage**: Infrastructure Design
 - **Current Unit**: Infrastructure and Operational Support
-- **Next Stage**: NFR design questions and artifact generation
+- **Next Stage**: Infrastructure design questions and artifact generation
 - **Status**: In progress on branch `construction`

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -1559,3 +1559,27 @@ Inceptionを完了させてください。READMEもInception完了に併せ更�
 **Context**: CONSTRUCTION - NFR Design approval gate
 
 ---
+
+## NFR Design Approval and Infrastructure Design Start
+**Timestamp**: 2026-05-10T16:25:29+09:00
+**User Input**: "承認します。次に進めてください。"
+**AI Response**: "Treated the message as approval of the Infrastructure and Operational Support NFR design, updated workflow state to Infrastructure Design, and started infrastructure design planning for the same unit."
+**Context**: CONSTRUCTION - NFR Design approval and transition to Infrastructure Design
+
+---
+
+## Infrastructure Design Answers Intake
+**Timestamp**: 2026-05-10T19:48:17+09:00
+**User Input**: "回答しました。"
+**AI Response**: "The infrastructure design plan file itself was still unanswered, but the immediately preceding diff comments provided the six answers needed for the plan. Reflected those answers into `aidlc-docs/construction/plans/infrastructure-and-operational-support-infrastructure-design-plan.md` and generated the infrastructure design artifacts under `aidlc-docs/construction/infrastructure-and-operational-support/infrastructure-design/`."
+**Context**: CONSTRUCTION - Infrastructure Design generation
+
+---
+
+## Infrastructure Design Approval Prompt
+**Timestamp**: 2026-05-10T19:48:17+09:00
+**User Input**: ""
+**AI Response**: "Infrastructure design complete for `Infrastructure and Operational Support`. Requested review and approval of the infrastructure design artifacts before proceeding to Code Generation."
+**Context**: CONSTRUCTION - Infrastructure Design approval gate
+
+---

--- a/aidlc-docs/construction/infrastructure-and-operational-support/infrastructure-design/deployment-architecture.md
+++ b/aidlc-docs/construction/infrastructure-and-operational-support/infrastructure-design/deployment-architecture.md
@@ -1,0 +1,106 @@
+# Infrastructure and Operational Support デプロイアーキテクチャ
+
+## 概要
+本書は `Infrastructure and Operational Support` Unit のデプロイ構成を示す。MVP では AWS 上の単一環境を前提とし、公開入口からワークフロー実行、状態保存、ログ、通知までの実行経路を定義する。
+
+## 1. 配置方針
+
+### 環境
+- MVP は単一環境で構成する。
+- 後続フェーズで `dev` / `stg` / `prod` へ拡張できるよう、命名と構成の一貫性を持たせる。
+
+### AWS サービス配置
+- 公開入口: `Amazon API Gateway`
+- API 起動処理: `AWS Lambda`
+- ワークフロー制御: `AWS Step Functions`
+- 現在状態保存: `Amazon DynamoDB`
+- イベントログ保存: `Amazon DynamoDB`
+- 秘密情報管理: `AWS Secrets Manager`
+- ログ/メトリクス/アラーム: `Amazon CloudWatch`
+- 高重要度障害通知: `Slack Webhook`
+
+## 2. 実行アーキテクチャ
+
+```text
+Frontend
+  |
+  v
+API Gateway
+  |
+  v
+Workflow Starter Lambda
+  |
+  v
+Step Functions State Machine
+  | \
+  |  \--> DynamoDB (Request State)
+  |   \
+  |    \-> DynamoDB (Event Log)
+  |
+  +--> Task Lambdas / Adapters
+           |
+           +--> Secrets Manager
+           +--> CloudWatch Logs / Metrics
+           +--> Slack Webhook (high severity only)
+```
+
+## 3. コンポーネント別デプロイ責務
+
+### API Gateway
+- フロント向けの公開 HTTP エンドポイントを提供する。
+- MVP では最小限の API 群のみを公開する。
+
+### Workflow Starter Lambda
+- 入口 API の処理を受け、初期 `Request` 作成と Step Functions 起動を行う。
+- 長時間処理は持たず、オーケストレーション開始に責務を限定する。
+
+### Step Functions State Machine
+- Retry / Backoff
+- 分岐
+- 待機
+- `FATAL` への遷移
+- 後続 Lambda 呼び出し
+
+### DynamoDB
+- `Request State` と `Event Log` を格納する。
+- 単一ストア上で責務分離を行う。
+
+### Secrets Manager
+- Slack Webhook などの秘匿情報を保持する。
+
+### CloudWatch
+- ログ、メトリクス、アラームを集約する。
+
+## 4. 障害時のデプロイ上の振る舞い
+
+### 一時障害
+- Step Functions の Retry / Backoff で吸収する。
+- Retry 試行は CloudWatch Logs と Event Log に残す。
+
+### FATAL 障害
+- UI 側の失敗表示を優先する。
+- 高重要度障害は Slack Webhook へ通知する。
+- 通知失敗は主フロー失敗へ昇格させない。
+
+## 5. 命名・分離方針
+
+### 命名
+- Unit 名を含む命名を基本とする。
+- 例:
+  - `infra-support-workflow-starter`
+  - `infra-support-state-machine`
+  - `infra-support-request-state`
+  - `infra-support-event-log`
+  - `infra-support-secrets`
+
+### 分離
+- AWS アカウントおよびネットワークは共有前提
+- リソース識別と責務境界は Unit 単位で明確化
+
+## 6. 将来拡張ポイント
+- 複数環境化
+- API Gateway 認証追加
+- CloudWatch ダッシュボード追加
+- X-Ray などのトレーシング追加
+- Slack 以外の通知チャネル追加
+- 一部ワークロードのコンテナ実行基盤移行

--- a/aidlc-docs/construction/infrastructure-and-operational-support/infrastructure-design/infrastructure-design.md
+++ b/aidlc-docs/construction/infrastructure-and-operational-support/infrastructure-design/infrastructure-design.md
@@ -1,0 +1,137 @@
+# Infrastructure and Operational Support インフラ設計
+
+## 概要
+本書は `Infrastructure and Operational Support` Unit の論理コンポーネントを、実際の AWS サービスへ対応付けたインフラ設計を定義する。対象は、公開入口、ワークフロー制御、状態保存、イベント記録、秘密情報管理、監視、および通知基盤である。
+
+## 1. クラウド・デプロイ前提
+
+### クラウド方針
+- クラウドプロバイダは AWS を前提とする。
+- MVP は単一環境で構成する。
+
+### 理由
+- 現時点では MVP 優先であり、環境分離よりも構成確定と実装速度を優先する。
+- `dev` のみをまず成立させ、後続で `stg` や `prod` を追加できるようにする。
+
+## 2. 公開入口のサービスマッピング
+
+### Public Request Entry
+- 論理コンポーネント `Public Request Entry` は `Amazon API Gateway` にマッピングする。
+
+### 役割
+- フロントからの HTTP リクエスト受付
+- バックエンド Lambda へのルーティング
+- 将来的な認証、レート制御、CORS 対応の拡張余地の確保
+
+### 設計方針
+- API Gateway は公開入口専用とする。
+- 内部コンポーネント間通信には利用しない。
+
+## 3. 実行・オーケストレーションのサービスマッピング
+
+### Workflow Starter
+- `AWS Lambda`
+
+### Workflow State Coordinator
+- `AWS Step Functions`
+
+### 設計方針
+- フロントからの初回要求は `API Gateway -> Lambda -> Step Functions` で開始する。
+- 再試行、待機、分岐、`FATAL` への遷移は Step Functions 主導で管理する。
+- Lambda 側での独自再試行ループは原則持たせない。
+
+## 4. 状態保存・イベント記録のサービスマッピング
+
+### Request State Store
+- `Amazon DynamoDB`
+
+### Request Event Log
+- `Amazon DynamoDB`
+
+### 保存方針
+- 現在状態とイベントログは、どちらも DynamoDB で管理する。
+- 分離方法は、単一テーブル設計または論理分割されたテーブル設計のいずれかで実装できるようにする。
+- 現段階では「DynamoDB 上で分離する」ことを固定し、具体的なキー設計は実装時に詰める。
+
+### 理由
+- 低遅延な読み書きが必要
+- 現在状態とイベント履歴の双方に対してスケーラブルなアクセスが必要
+- MVP 段階では別ストレージ分離より構成の単純さを優先できる
+
+## 5. 秘密情報管理のサービスマッピング
+
+### 対象
+- Slack Webhook URL
+- 将来追加される外部 API 認証情報
+- 環境ごとの設定値のうち秘匿すべきもの
+
+### 採用サービス
+- `AWS Secrets Manager`
+
+### 設計方針
+- 秘密情報は Secrets Manager で集中管理する。
+- Lambda からは実行時に必要な秘密情報のみ参照する。
+- ソースコードや通常の環境変数へ平文埋め込みしない。
+
+## 6. 監視・ログ・通知のサービスマッピング
+
+### ログ
+- `Amazon CloudWatch Logs`
+
+### メトリクス
+- `Amazon CloudWatch Metrics`
+
+### アラーム
+- `Amazon CloudWatch Alarms`
+
+### 通知
+- `Slack Webhook`
+
+### 設計方針
+- MVP の監視は `CloudWatch Logs / Metrics / Alarms` の基本構成で十分とする。
+- 高重要度障害のみ Slack Webhook へ通知する。
+- ダッシュボードやフルトレーシングはこの段階では必須としない。
+
+## 7. リソース分離方針
+
+### 方針
+- Unit 単位で論理分離する。
+- AWS アカウントや VPC は共有前提でよい。
+
+### 含意
+- Step Functions ステートマシン名、Lambda 名、DynamoDB テーブル名、Secrets 名は Unit を識別できる命名にする。
+- 共有基盤を使いながらも、リソース責務は Unit ごとに追跡できるようにする。
+
+## 8. ネットワーク方針
+
+### 基本方針
+- 公開トラフィックは API Gateway で受ける。
+- 内部処理は AWS マネージドサービス間連携を基本とし、追加の内部 HTTP 中継は設けない。
+
+### 含意
+- `API Gateway -> Lambda`
+- `Lambda -> Step Functions`
+- `Step Functions -> Lambda`
+- `Lambda -> DynamoDB`
+- `Lambda -> Secrets Manager`
+- `Lambda -> Slack Webhook`
+
+## 9. 共有インフラの扱い
+
+### 現時点の判断
+- 共有 AWS アカウント内で運用する。
+- ただしリソース命名と責務境界は Unit 単位で明確化する。
+
+### shared-infrastructure.md について
+- 現時点では Unit 横断の共有インフラ方針を新規文書化するほどではない。
+- 将来、複数 Unit で共通の API Gateway、通知基盤、監視基盤、VPC を詳細定義する段階で別紙化を検討する。
+
+## 10. 拡張ルール適合性
+
+### Security Baseline
+- 状態: N/A
+- 理由: `aidlc-state.md` で無効化されている。
+
+### Property-Based Testing
+- 状態: N/A
+- 理由: この段階はインフラマッピング設計であり、PBT の適用対象ではない。

--- a/aidlc-docs/construction/plans/infrastructure-and-operational-support-infrastructure-design-plan.md
+++ b/aidlc-docs/construction/plans/infrastructure-and-operational-support-infrastructure-design-plan.md
@@ -1,0 +1,80 @@
+# Infrastructure and Operational Support Infrastructure Design Plan
+
+## Progress Checklist
+- [x] Review functional and NFR design artifacts
+- [x] Identify infrastructure mapping decision points
+- [x] Draft infrastructure clarification questions
+- [x] Collect user answers for the infrastructure questions
+- [x] Generate `infrastructure-design.md`
+- [x] Generate `deployment-architecture.md`
+
+## Unit Summary
+- Unit name: `Infrastructure and Operational Support`
+- Scope: mapping workflow orchestration, request state management, event logging, failure notification, and public request entry into actual AWS services
+- Design focus: service mapping, deployment topology, environment separation, operational notification path, and shared versus unit-specific infrastructure boundaries
+
+## Question 1
+公開入口の実装として、MVP ではどの入口を第一候補にしますか。
+
+A) API Gateway をフロント向け公開入口として採用する  
+B) Lambda Function URL など、より軽量な公開入口を優先する  
+C) 入口は後続 Unit と合わせて決めるため、この段階では論理境界のみ定義する  
+D) フロント公開入口はこの Unit では持たず、内部起動前提で進める  
+E) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+## Question 2
+Request の現在状態とイベントログの保存先は、MVP ではどの分け方を優先しますか。
+
+A) どちらも DynamoDB で管理し、テーブルまたは項目設計で分離する  
+B) 現在状態は DynamoDB、イベントログは別ストレージへ分ける  
+C) まずは単一ストレージで簡単に実装し、将来分離する  
+D) 保存方式は Infrastructure Design ではまだ固定しない  
+E) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+## Question 3
+Slack 通知用 Webhook や各種秘密情報の管理方法として、MVP で優先する方針はどれですか。
+
+A) AWS Secrets Manager で集中管理する  
+B) SSM Parameter Store を中心に使う  
+C) 開発速度優先で環境変数中心にする  
+D) 秘密情報ごとに使い分ける前提で進める  
+E) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+## Question 4
+運用監視の構成として、MVP ではどの粒度を優先しますか。
+
+A) CloudWatch Logs / Metrics / Alarm の基本構成で十分  
+B) A に加えてダッシュボードも最初から用意したい  
+C) A に加えて X-Ray などのトレーシングも入れたい  
+D) ログ中心で進め、メトリクスやアラームは最小限にしたい  
+E) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+## Question 5
+この Unit のリソース分離方針として、MVP ではどれを優先しますか。
+
+A) Unit 単位で論理分離するが、AWS アカウントや VPC は共有前提でよい  
+B) 可能な限り Unit ごとに独立したリソース群へ分けたい  
+C) MVP では共有リソースを多めに使い、分離は後回しにする  
+D) 分離方針は後続 Unit を見てから最終決定したい  
+E) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+## Question 6
+デプロイ環境の切り方として、現時点で最低限必要なのはどれですか。
+
+A) `dev` と `prod` の 2 環境  
+B) `dev` / `stg` / `prod` の 3 環境  
+C) MVP では単一環境でよい  
+D) まずは `dev` のみを定義し、他環境は後回しにする  
+E) Other (please describe after [Answer]: tag below)
+
+[Answer]: C


### PR DESCRIPTION
## 概要
`Infrastructure and Operational Support` Unit について、CONSTRUCTION フェーズの設計を `Infrastructure Design` まで追加しました。

## 変更内容
- `aidlc-docs/aidlc-state.md` を CONSTRUCTION / Infrastructure Design の進行状態に更新
- `aidlc-docs/construction/plans/infrastructure-and-operational-support-infrastructure-design-plan.md` を追加・完了更新
- `aidlc-docs/construction/infrastructure-and-operational-support/infrastructure-design/infrastructure-design.md` を追加
- `aidlc-docs/construction/infrastructure-and-operational-support/infrastructure-design/deployment-architecture.md` を追加
- `aidlc-docs/audit.md` に Infrastructure Design の進行ログを追記

## 設計ポイント
- 公開入口は `API Gateway` を第一候補とし、内部コンポーネント間通信には使わない方針
- 実行経路は `API Gateway -> Lambda -> Step Functions` を基本形として整理
- `Request State` と `Event Log` は DynamoDB 上で分離管理する前提
- Slack Webhook などの秘密情報は `Secrets Manager` で集中管理
- 監視は `CloudWatch Logs / Metrics / Alarms` の基本構成を採用
- 高重要度障害のみ Slack Webhook 通知を行う
- MVP は単一環境前提、AWS アカウントや VPC は共有しつつ Unit 単位で論理分離する方針

## レビューしてほしい点
- API Gateway を公開入口専用とする整理が妥当か
- DynamoDB での現在状態とイベントログ分離方針が適切か
- Secrets Manager / CloudWatch / Slack Webhook の組み合わせが MVP として十分か
- 単一環境・共有アカウント前提の分離方針が妥当か

## テスト
- ドキュメント更新のみのため未実施
